### PR TITLE
Rebrand Refact to CodeAlive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 <p align="center">
-  <img width="300" alt="Refact" src="src/main/resources/icons/refact_logo.svg"/>
+  <img width="300" alt="CodeAlive" src="src/main/resources/icons/codealive_logo.svg"/>
 </p>
 
 ---
 
 [![Discord](https://img.shields.io/discord/1037660742440194089?logo=discord&label=Discord&link=https%3A%2F%2Fsmallcloud.ai%2Fdiscord)](https://smallcloud.ai/discord)
-[![Twitter Follow](https://img.shields.io/twitter/follow/refact_ai)](https://twitter.com/intent/follow?screen_name=refact_ai)
-![License](https://img.shields.io/github/license/smallcloudai/refact-intellij)
+[![Twitter Follow](https://img.shields.io/twitter/follow/codealive_ai)](https://twitter.com/intent/follow?screen_name=codealive_ai)
+![License](https://img.shields.io/github/license/smallcloudai/codealive-intellij)
 
 
-# refact-intellij
-*Refact for JetBrains is a free, open-source AI code assistant* 
-- **Code suggestions and completions:** Refact suggests potential code completions based on the context of your code, looking up and down. It can suggest whole functions, classes, commonly used programming patterns, libraries, and APIs usage.
+# codealive-intellij
+*CodeAlive for JetBrains is a free, open-source AI code assistant* 
+- **Code suggestions and completions:** CodeAlive suggests potential code completions based on the context of your code, looking up and down. It can suggest whole functions, classes, commonly used programming patterns, libraries, and APIs usage.
 - **AI Toolbox:** Apply functions for bug detection and fixing, code refactoring, documentation assistance, code review, and more. 
 - **Integrated AI Chat:** Use natural language to ask code questions and get answers seamlessly.
   
   ![image](https://github.com/smallcloudai/refact-intellij/blob/main/almost-all-features-05x.jpg)
 
 ## Getting Started
-Once [installed](https://plugins.jetbrains.com/plugin/20647-refact-ai), look for the Refact.ai logo in the status bar or the sidebar, click 'login', and agree to T&C. Start typing some code, and autocomplete will make suggestions automatically! Press F1 to access the AI toolbox functions. Refact has a simple, user-friendly interface that makes it easy to use, even for those new to AI tools.
-If you have your own NVIDIA GPU, you can try the [self-hosted version](https://github.com/smallcloudai/refact).
+Once [installed](https://plugins.jetbrains.com/plugin/20647-codealive), look for the CodeAlive logo in the status bar or the sidebar, click 'login', and agree to T&C. Start typing some code, and autocomplete will make suggestions automatically! Press F1 to access the AI toolbox functions. CodeAlive has a simple, user-friendly interface that makes it easy to use, even for those new to AI tools.
+If you have your own NVIDIA GPU, you can try the [self-hosted version](https://github.com/smallcloudai/codealive).
 ## Support & Feedback
 Join our Discord to get to know other community members, send us feedback or suggestions, and get support.

--- a/src/main/kotlin/com/smallcloud/refactai/Resources.kt
+++ b/src/main/kotlin/com/smallcloud/refactai/Resources.kt
@@ -12,7 +12,7 @@ import javax.swing.Icon
 import javax.swing.UIManager
 
 
-fun getThisPlugin() = PluginManager.getPlugins().find { it.name == "Refact.ai" }
+fun getThisPlugin() = PluginManager.getPlugins().find { it.name == "CodeAlive" }
 
 private fun getHomePath(): File {
     return getThisPlugin()!!.pluginPath.toFile()
@@ -60,7 +60,7 @@ private fun getBinPrefix(): String {
 object Resources {
     val binPrefix: String = getBinPrefix()
 
-    const val defaultCloudAuthLink: String = "https://refact.smallcloud.ai/authentication?token=%s&utm_source=plugin&utm_medium=jetbrains&utm_campaign=login"
+    const val defaultCloudAuthLink: String = "https://codealive.smallcloud.ai/authentication?token=%s&utm_source=plugin&utm_medium=jetbrains&utm_campaign=login"
     val defaultCloudUrl: URI = URI("https://www.smallcloud.ai")
     val defaultCodeCompletionUrlSuffix = URI("v1/code-completion")
     val cloudUserMessage: URI = defaultCloudUrl.resolve("/v1/user-message")
@@ -68,11 +68,11 @@ object Resources {
     val defaultSnippetAcceptedUrlSuffix: URI = URI("v1/snippet-accepted")
     val version: String = getVersion()
     const val client: String = "jetbrains"
-    const val titleStr: String = "Refact.ai"
+    const val titleStr: String = "CodeAlive"
     val pluginId: PluginId = getPluginId()
     val jbBuildVersion: String = ApplicationInfo.getInstance().build.toString()
-    const val refactAIRootSettingsID = "refactai_root"
-    const val refactAIAdvancedSettingsID = "refactai_advanced_settings"
+    const val refactAIRootSettingsID = "codealive_root"
+    const val refactAIAdvancedSettingsID = "codealive_advanced_settings"
 
     object Icons {
         private fun brushForTheme(icon: Icon): Icon {
@@ -87,10 +87,10 @@ object Resources {
             return brushForTheme(IconLoader.getIcon(path, Resources::class.java))
         }
 
-        val LOGO_RED_12x12: Icon = IconLoader.getIcon("/icons/refactai_logo_red_12x12.svg", Resources::class.java)
-        val LOGO_RED_13x13: Icon = IconLoader.getIcon("/icons/refactai_logo_red_13x13.svg", Resources::class.java)
-        val LOGO_12x12: Icon = makeIcon("/icons/refactai_logo_12x12.svg")
-        val LOGO_RED_16x16: Icon = IconLoader.getIcon("/icons/refactai_logo_red_16x16.svg", Resources::class.java)
+        val LOGO_RED_12x12: Icon = IconLoader.getIcon("/icons/codealive_logo_red_12x12.svg", Resources::class.java)
+        val LOGO_RED_13x13: Icon = IconLoader.getIcon("/icons/codealive_logo_red_13x13.svg", Resources::class.java)
+        val LOGO_12x12: Icon = makeIcon("/icons/codealive_logo_12x12.svg")
+        val LOGO_RED_16x16: Icon = IconLoader.getIcon("/icons/codealive_logo_red_16x16.svg", Resources::class.java)
 
         val COIN_16x16: Icon = makeIcon("/icons/coin_16x16.svg")
         val HAND_12x12: Icon = makeIcon("/icons/hand_12x12.svg")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,29 +2,29 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin require-restart="true">
     <id>com.smallcloud.codify</id>
-    <name>Refact.ai</name>
+    <name>CodeAlive</name>
     <vendor email="info@smallcloud.ai"
-            url="https://refact.ai/?utm_source=jb&amp;utm_medium=marketplace&amp;utm_campaign=plugin">smallcloudai
+            url="https://codealive.ai/?utm_source=jb&amp;utm_medium=marketplace&amp;utm_campaign=plugin">smallcloudai
     </vendor>
 
     <description><![CDATA[
-<h2>Refact.ai: The AI Assistant for Code Writing and Refactoring.</h2>
+<h2>CodeAlive: The AI Assistant for Code Writing and Refactoring.</h2>
 <p>
-    Refact is a cutting-edge AI tool designed to assist developers in writing and refining code.
+    CodeAlive is a cutting-edge AI tool designed to assist developers in writing and refining code.
     It’s fast and supports Python, Java, PHP, C++, Javascript, TypeScript, and 20 more programming languages.
 </p>
 <p>
     Try for free today and make your programming more enjoyable!
 </p>
 <p>
-    🔒 We put your privacy first. Refact allows you to restrict access to particular files or projects,
+    🔒 We put your privacy first. CodeAlive allows you to restrict access to particular files or projects,
     ensuring that your private code or confidential files are protected. And we don't collect datasets on the server
     side.
 </p>
 
-<h3 style="margin-bottom:0">Functions That You Can Use in Refact:</h3>
+<h3 style="margin-bottom:0">Functions That You Can Use in CodeAlive:</h3>
 <ul style="margin-top:5">
-    <li><b>Code Completion:</b> As you write code, Refact suggests potential code completions based on the
+    <li><b>Code Completion:</b> As you write code, CodeAlive suggests potential code completions based on the
         context of your code, looking up and down. It can suggest whole functions, classes,
         commonly used programming patterns, libraries, and APIs usage.
     </li>
@@ -43,16 +43,16 @@
 
 <h3>Self-Hosting</h3>
 <p>
-    Our own AI model behind Refact.ai is state-of-the-art (for the size and latency).
+    Our own AI model behind CodeAlive is state-of-the-art (for the size and latency).
     The weights are free to download on <a href="https://huggingface.co/smallcloudai">Huggingface</a>.
 </p>
 <p>
-    If you have your own NVIDIA GPU, you can try the <a href="https://refact.smallcloud.ai/docker">self-hosted
+    If you have your own NVIDIA GPU, you can try the <a href="https://codealive.smallcloud.ai/docker">self-hosted
     version</a>.
 </p>
 
-<h3>Refact Enterprise Edition</h3>
-<p>Refact Enterprise Edition is tailored for teams looking for complete control of their Refact experience. This plan includes a suite of advanced features such as:</p>
+<h3>CodeAlive Enterprise Edition</h3>
+<p>CodeAlive Enterprise Edition is tailored for teams looking for complete control of their CodeAlive experience. This plan includes a suite of advanced features such as:</p>
 
 <ul>
 	<li><strong>Fine-Tuning</strong></li>
@@ -60,7 +60,7 @@
 	<li><strong>vLLM Support</strong></li>
 </ul>
 
-<p>For a detailed guide on all the features and benefits of the Refact Enterprise Edition, please refer to our <a href="https://docs.refact.ai/guides/enterprise/">documentation</a>.</p>
+<p>For a detailed guide on all the features and benefits of the CodeAlive Enterprise Edition, please refer to our <a href="https://docs.codealive.ai/guides/enterprise/">documentation</a>.</p>
 
 
 <h3>Support & Feedback</h3>
@@ -77,18 +77,18 @@
 ]]></description>
 
     <change-notes><![CDATA[
-<p>Refact.ai is an AI coding assistant, available for JetBrains IDEs and Visual Studio Code.</p>
+<p>CodeAlive is an AI coding assistant, available for JetBrains IDEs and Visual Studio Code.</p>
 
 <p>In this major release, we introduce:</p>
 <ul>
 <li>RustRover support.</li>
-<li>All new plugins are powered by <a href="https://github.com/smallcloudai/refact-lsp">Refact LSP</a>, our new open-source server written in Rust! Refact LSP converts high-level code completion, or chat requests into low-level LLM prompts and converts results back. </li>
+<li>All new plugins are powered by <a href="https://github.com/smallcloudai/codealive-lsp">CodeAlive LSP</a>, our new open-source server written in Rust! CodeAlive LSP converts high-level code completion, or chat requests into low-level LLM prompts and converts results back. </li>
 <li>Bugfixes and performance improvements</li>
 </ul>
 
 <p>Our code completion is now faster and more responsive with improved indentation, multiline code completion and chat responsiveness.</p>
 
-<p>In the Pro version, you can enjoy all of those AI features,
+<p>In CodeAlive Pro, you can enjoy all of these AI features,
 integrated into a single package that follows your privacy settings.</p>
 
 <p>Check out our Trial version, ready to start working for you in seconds!</p>


### PR DESCRIPTION
Updated branding from 'Refact' to 'CodeAlive' in key project files. This includes changes to plugin.xml, README.md, and Resources.kt. Updated URLs, descriptions, and icon references to reflect the new brand. Follow-up tasks may include renaming additional files and references.



Created with [**Solver**](https://solverai.com)